### PR TITLE
Add OpenMailBox

### DIFF
--- a/services.json
+++ b/services.json
@@ -137,6 +137,16 @@
         "port": 587
     },
 
+    "OpenMailBox": {
+        "aliases": [
+            "OMB",
+            "openmailbox.org"
+        ],
+        "host": "smtp.openmailbox.org",
+        "port": 465,
+        "secure": true
+    },
+
     "Postmark": {
         "aliases": ["PostmarkApp"],
         "host": "smtp.postmarkapp.com",


### PR DESCRIPTION
Adds the openmailbox.org SMTP server configuration.

Is the list supposed to be in alphabetical order? If so, there is a problem with Naver, above and below it, there is a M-starting server.