### PR TITLE
Refine SES service to include each region.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Service names are case insensitive
   * **'SendCloud'**
   * **'SendGrid'**
   * **'SES'**
+  * **'SES-US-EAST-1'**
+  * **'SES-US-WEST-1'**
+  * **'SES-EU-WEST-1'**
   * **'Sparkpost'**
   * **'Yahoo'**
   * **'Yandex'**

--- a/services.json
+++ b/services.json
@@ -187,6 +187,22 @@
         "port": 465,
         "secure": true
     },
+    "SES-US-EAST-1": {
+        "host": "email-smtp.us-east-1.amazonaws.com",
+        "port": 465,
+        "secure": true
+    },
+    "SES-US-WEST-1": {
+        "host": "email-smtp.us-west-1.amazonaws.com",
+        "port": 465,
+        "secure": true
+    },
+    "SES-EU-WEST-1": {
+        "host": "email-smtp.eu-west-1.amazonaws.com",
+        "port": 465,
+        "secure": true
+    },
+    
 
     "Sparkpost": {
         "aliases": [


### PR DESCRIPTION
Add SES-US-EAST-1 with hostname set to mail-smtp.us-east-1.amazonaws.com
Add SES-US-WEST-1 with hostname set to mail-smtp.us-west-2.amazonaws.com
Add SES-EU-WEST-1 with hostname set to mail-smtp.eu-west-1.amazonaws.com
Add additional SES services to README.md