### PR TITLE
Rename SES-US-WEST-1 service to SES-US-WEST-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Service names are case insensitive
   * **'SendGrid'**
   * **'SES'**
   * **'SES-US-EAST-1'**
-  * **'SES-US-WEST-1'**
+  * **'SES-US-WEST-2'**
   * **'SES-EU-WEST-1'**
   * **'Sparkpost'**
   * **'Yahoo'**

--- a/services.json
+++ b/services.json
@@ -192,8 +192,8 @@
         "port": 465,
         "secure": true
     },
-    "SES-US-WEST-1": {
-        "host": "email-smtp.us-west-1.amazonaws.com",
+    "SES-US-WEST-2": {
+        "host": "email-smtp.us-west-2.amazonaws.com",
         "port": 465,
         "secure": true
     },


### PR DESCRIPTION
`email-smtp.us-west-1.amazonaws.com` doesn't exist.
The correct endpoint should be `email-smtp.us-west-2.amazonaws.com`
Documented at http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html