### PR TITLE
Outlook365

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Service names are case insensitive
   * **'Mandrill'**
   * **'Naver'**
   * **'OpenMailBox'**
+  * **'Outlook365'**
   * **'Postmark'**
   * **'QQ'**
   * **'QQex'**

--- a/services.json
+++ b/services.json
@@ -147,6 +147,15 @@
         "secure": true
     },
 
+    "Outlook365": {
+      "host": "smtp.office365.com",
+      "port": 587,
+      "secure": false,
+      "tls": {
+          "ciphers": "SSLv3"
+      }
+    },
+
     "Postmark": {
         "aliases": ["PostmarkApp"],
         "host": "smtp.postmarkapp.com",
@@ -202,7 +211,7 @@
         "port": 465,
         "secure": true
     },
-    
+
 
     "Sparkpost": {
         "aliases": [


### PR DESCRIPTION
added Outlook365 to list of known services. An outlook email account associated with an Office365 subscription uses a different host than standard outlook or hotmail. Was able to send email using work address, hosted by office 365.

Source: Screen shot from inside desktop app
<img width="584" alt="outlook365" src="https://cloud.githubusercontent.com/assets/21197155/18458640/98416502-7930-11e6-88d9-8e6708017f25.png">
